### PR TITLE
content-type fix

### DIFF
--- a/mailsnake/mailsnake.py
+++ b/mailsnake/mailsnake.py
@@ -21,7 +21,9 @@ class MailSnake(object):
         params.update(self.default_params)
 
         post_data = json.dumps(params)
-        response = urllib2.urlopen(url, post_data)
+        headers = {'Content-Type': 'application/json'}
+        request = urllib2.Request(url, post_data, headers)
+        response = urllib2.urlopen(request)
 
         return json.loads(response.read())
 


### PR DESCRIPTION
hi, i encountered an inconvenient problem when trying to set html contents for campaigns. server's response to posting 
{"apikey": "HERE_WAS_MY_API_KEY", "name": "content", "value": {"html": "="}, "cid": "CAMPAIGN_ID"}
by
{"error":"You must specify a apikey value for the campaignUpdate method","code":-90}

wasn't making much sense, but eventually setting the correct content type made it to behave

enjoy
