### PR TITLE
Add support for simplejson

### DIFF
--- a/mailsnake/mailsnake.py
+++ b/mailsnake/mailsnake.py
@@ -1,5 +1,8 @@
 import urllib2
-import json
+try:
+    import simplejson as json
+except ImportError:
+    import json
 
 class MailSnake(object):
     def __init__(self, apikey = '', extra_params = {}):


### PR DESCRIPTION
Thanks for the excellent library.

This commit adds support for simplejson, and thus support for Python 2.5. This is necessary to use mailsnake on Google App Engine, for example, and other older installations.

The simplejson import should be preferred, because the version in the stdlib (just called 'json') doesn't include the latest optimizations. The performance difference can be quite large.
